### PR TITLE
Add cookie consent popup

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,16 @@ You can add a social link panel in the footer by adding entries to the `social` 
 
 Assign either `font-awesome` or `mono-social` to the `iconFont` variable. The Mono social icons offer three styles of icons: -circle, rounded, or default (empty).
 
+## Cookie Consent Popup
+
+You can add & configure cookie consent popup for your blog in the `params` block in the `config.toml`. e.g.:
+
+```toml
+enableCookieConsent = true
+cookieConsentMessage = "This website uses cookies to ensure you get the best experience on our website."
+cookieConsentPrivacyLink = "https://cookiesandyou.com"
+
+```
 
 ## Nearly finished
 

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -21,6 +21,11 @@ hasCJKLanguage = false
 	enableDisqus = true
 	disqusShortname = "your_disqus_short_name"
 
+	# Add cookie consent popup
+	enableCookieConsent = true
+	cookieConsentMessage = "This website uses cookies to ensure you get the best experience on our website."
+	cookieConsentPrivacyLink = "https://cookiesandyou.com"
+
 
 	enableSummary = true
 	# Set the value to true if use description in post front matter replace content summary
@@ -65,8 +70,8 @@ hasCJKLanguage = false
 
 	# Choose a font for the social icons in the footer. Either "mono-social" or "font-awesome"
 	iconFont = "font-awesome"
-  # The social icons can be styled differently if you use mono as font - circle, rounded, or empty
-  socialIconStyle = ""
+	# The social icons can be styled differently if you use mono as font - circle, rounded, or empty
+	socialIconStyle = ""
 
 
 # Add additional social link entries underneath

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -4,7 +4,7 @@
 		<meta charset="utf-8">
 		<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
 		<meta name="viewport" content="width=device-width, initial-scale=1">
-		{{ if .Site.Params.enableTwitterCard }} 
+		{{ if .Site.Params.enableTwitterCard }}
 			{{ partial "twitter-cards.html" . }}
 		{{ end }}
 		{{ with .Site.Params.author }}<meta name="author" content="{{ . }}">{{ end }}
@@ -14,6 +14,10 @@
 		<link rel="shortcut icon" href="{{ .Site.BaseURL }}images/favicon.ico">
 		<link rel="stylesheet" href="{{ .Site.BaseURL }}css/style.css">
 		<link rel="stylesheet" href="{{ .Site.BaseURL }}css/syntax.css">
+
+		{{ if .Site.Params.enableCookieConsent }}
+		<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/cookieconsent@3/build/cookieconsent.min.css" />
+		{{ end }}
 
 		{{ if eq .Site.Params.iconFont "font-awesome" }}
 		<link rel="stylesheet" href="{{ .Site.BaseURL }}css/font-awesome.min.css">

--- a/layouts/partials/js.html
+++ b/layouts/partials/js.html
@@ -8,3 +8,27 @@
 {{ if .Site.Params.enableGoogleAnalytics }}
   {{ template "_internal/google_analytics.html" . }}
 {{ end }}
+
+{{ if .Site.Params.enableCookieConsent }}
+<script src="https://cdn.jsdelivr.net/npm/cookieconsent@3/build/cookieconsent.min.js" data-cfasync="false"></script>
+<script>
+  window.cookieconsent.initialise({
+      palette: {
+          popup: {
+              background: "#f7f7f7",
+              text: "#777"
+          },
+          button: {
+              background: "transparent",
+              text: "#e20074",
+              border: "#e20074"
+          }
+      },
+      position: "bottom-right",
+      content: {
+          message: "{{ .Site.Params.cookieConsentMessage }}",
+          href: "{{ .Site.Params.cookieConsentPrivacyLink }}"
+      }
+  });
+</script>
+{{ end }}


### PR DESCRIPTION
Example:
![image](https://user-images.githubusercontent.com/18228995/96279195-a45e6600-0fd6-11eb-8210-606d1e78a9d3.png)

Can be configured in `params` section of `config.toml` like:

```toml
enableCookieConsent = true
cookieConsentMessage = "This website uses cookies to ensure you get the best experience on our website."
cookieConsentPrivacyLink = "https://cookiesandyou.com"
```