### PR TITLE
Change syntax highlighting theme to github

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -466,7 +466,12 @@ img {
 
 /* selects all code elements that don't have class defined, which is single quote markdown highlighting */
 code:not([class]) {
-  color: #ea0a8e;
+  color: #23282d;
+  padding: .2em .3em;
+  border-radius: 6px;
+  background-color: #F6F8FA;
+  font-size: .95em;
+  font-family: monospace;
 }
 
 /* Made with Cactus Badge */

--- a/static/css/syntax.css
+++ b/static/css/syntax.css
@@ -1,4 +1,4 @@
-/* Background */ .chroma { background-color: #fff; font-family: monospace; font-size: .85em; }
+/* Background */ .chroma { background-color: #F6F8FA; font-family: monospace; font-size: .85em; padding: .2em; overflow-x: auto;}
 /* Other */ .chroma .x {  }
 /* Error */ .chroma .err { color: #a61717; background-color: #e3d2d2 }
 /* LineTableTD */ .chroma .lntd { vertical-align: top; padding: 0; margin: 0; border: 0; }

--- a/static/css/syntax.css
+++ b/static/css/syntax.css
@@ -1,4 +1,4 @@
-/* Background */ .chroma { background-color: #fbf4f8; font-family: monospace; font-size: 1em; }
+/* Background */ .chroma { background-color: #fff; font-family: monospace; font-size: .85em; }
 /* Other */ .chroma .x {  }
 /* Error */ .chroma .err { color: #a61717; background-color: #e3d2d2 }
 /* LineTableTD */ .chroma .lntd { vertical-align: top; padding: 0; margin: 0; border: 0; }


### PR DESCRIPTION
- changed theme to `github` by running `hugo gen chromastyles --style=github > syntax.css`
- changed the background to white to match deafult theme background
- turned off line numbers (but that needs to be done in blog repo since its configured via `config.toml`)

before:
![image](https://user-images.githubusercontent.com/18228995/124296279-11605e80-db5a-11eb-9291-48fc0105b867.png)


now:
![image](https://user-images.githubusercontent.com/18228995/124296190-f857ad80-db59-11eb-869b-a29be0a2f85c.png)
